### PR TITLE
Add typescript generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ askama = { version = "0.11.1", default-features = false, features = ["config"] }
 toml = "0.5"
 clap = { version = "3.2.22", features = ["derive"] }
 heck = "0.4"
+paste = "1.0"
+once_cell = "1.12"
 
 [build-dependencies]
 uniffi_build = { version = "0.23.0" }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # breez-sdk-rn-generator
 
 This utility generated the breez-sdk React Native package code.
+
+## Prerequisites ##
+
+```bash
+brew install ktlint kotlin
+```
+
+```bash
+yarn global add tslint typescript
+```

--- a/askama.toml
+++ b/askama.toml
@@ -1,6 +1,6 @@
 [general]
 # Directories to search for templates, relative to the crate root.
-dirs = [ "src/gen_kotlin/templates" ]
+dirs = [ "src/gen_kotlin/templates", "src/gen_typescript/templates" ]
 
 [[syntax]]
 name = "rn"

--- a/src/gen_typescript/callback_interface.rs
+++ b/src/gen_typescript/callback_interface.rs
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
+
+pub struct CallbackInterfaceCodeType {
+    id: String,
+}
+
+impl CallbackInterfaceCodeType {
+    pub fn new(id: String) -> Self {
+        Self { id }
+    }
+}
+
+impl CodeType for CallbackInterfaceCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        oracle.class_name(&self.id)
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.id)
+    }
+
+    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+        unreachable!();
+    }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
+        nm.to_string()
+    }
+}

--- a/src/gen_typescript/compounds.rs
+++ b/src/gen_typescript/compounds.rs
@@ -74,7 +74,7 @@ impl MapCodeType {
 impl CodeType for MapCodeType {
     fn type_label(&self, oracle: &dyn CodeOracle) -> String {
         format!(
-            "Dictionary<{}, {}>",
+            "Record<{}, {}>",
             self.key().type_label(oracle),
             self.value().type_label(oracle),
         )
@@ -82,7 +82,7 @@ impl CodeType for MapCodeType {
 
     fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
         format!(
-            "Dictionary{}{}",
+            "Record{}{}",
             self.key().type_label(oracle),
             self.value().type_label(oracle),
         )

--- a/src/gen_typescript/compounds.rs
+++ b/src/gen_typescript/compounds.rs
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use paste::paste;
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal, TypeIdentifier};
+
+fn render_literal(oracle: &dyn CodeOracle, literal: &Literal, inner: &TypeIdentifier) -> String {
+    match literal {
+        Literal::Null => "null".into(),
+        Literal::EmptySequence => "[]".into(),
+        Literal::EmptyMap => "{}".into(),
+
+        // For optionals
+        _ => oracle.find(inner).literal(oracle, literal),
+    }
+}
+
+macro_rules! impl_code_type_for_compound {
+     ($T:ty, $type_label_pattern:literal, $canonical_name_pattern: literal) => {
+        paste! {
+            pub struct $T {
+                inner: TypeIdentifier,
+            }
+
+            impl $T {
+                pub fn new(inner: TypeIdentifier) -> Self {
+                    Self { inner }
+                }
+                fn inner(&self) -> &TypeIdentifier {
+                    &self.inner
+                }
+            }
+
+            impl CodeType for $T  {
+                fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+                    format!($type_label_pattern, oracle.find(self.inner()).type_label(oracle))
+                }
+
+                fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+                    format!($canonical_name_pattern, oracle.find(self.inner()).canonical_name(oracle))
+                }
+
+                fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+                    render_literal(oracle, literal, self.inner())
+                }
+            }
+        }
+    }
+ }
+
+impl_code_type_for_compound!(OptionalCodeType, "{}", "Optional{}");
+impl_code_type_for_compound!(SequenceCodeType, "{}[]", "Sequence{}");
+
+pub struct MapCodeType {
+    key: TypeIdentifier,
+    value: TypeIdentifier,
+}
+
+impl MapCodeType {
+    pub fn new(key: TypeIdentifier, value: TypeIdentifier) -> Self {
+        Self { key, value }
+    }
+
+    fn key(&self) -> &TypeIdentifier {
+        &self.key
+    }
+
+    fn value(&self) -> &TypeIdentifier {
+        &self.value
+    }
+}
+
+impl CodeType for MapCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        format!(
+            "Dictionary<{}, {}>",
+            self.key().type_label(oracle),
+            self.value().type_label(oracle),
+        )
+    }
+
+    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+        format!(
+            "Dictionary{}{}",
+            self.key().type_label(oracle),
+            self.value().type_label(oracle),
+        )
+    }
+
+    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+        render_literal(oracle, literal, &self.value)
+    }
+}

--- a/src/gen_typescript/custom.rs
+++ b/src/gen_typescript/custom.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use uniffi_bindgen::backend::{CodeOracle, CodeType};
+
+pub struct CustomCodeType {
+    name: String,
+}
+
+impl CustomCodeType {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl CodeType for CustomCodeType {
+    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+        self.name.clone()
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.name)
+    }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
+        nm.to_string()
+    }
+}

--- a/src/gen_typescript/enum_.rs
+++ b/src/gen_typescript/enum_.rs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
+
+pub struct EnumCodeType {
+    id: String,
+}
+
+impl EnumCodeType {
+    pub fn new(id: String) -> Self {
+        Self { id }
+    }
+}
+
+impl CodeType for EnumCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        oracle.class_name(&self.id)
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.id)
+    }
+
+    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+        if let Literal::Enum(v, _) = literal {
+            format!(
+                "{}.{}",
+                self.type_label(oracle),
+                oracle.enum_variant_name(v)
+            )
+        } else {
+            unreachable!();
+        }
+    }
+}

--- a/src/gen_typescript/error.rs
+++ b/src/gen_typescript/error.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
+
+pub struct ErrorCodeType {
+    id: String,
+}
+
+impl ErrorCodeType {
+    pub fn new(id: String) -> Self {
+        Self { id }
+    }
+}
+
+impl CodeType for ErrorCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        oracle.error_name(&self.id)
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.id)
+    }
+
+    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+        unreachable!();
+    }
+}

--- a/src/gen_typescript/external.rs
+++ b/src/gen_typescript/external.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use uniffi_bindgen::backend::{CodeOracle, CodeType};
+
+pub struct ExternalCodeType {
+    name: String,
+}
+
+impl ExternalCodeType {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl CodeType for ExternalCodeType {
+    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+        self.name.clone()
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.name)
+    }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
+        nm.into()
+    }
+}

--- a/src/gen_typescript/miscellany.rs
+++ b/src/gen_typescript/miscellany.rs
@@ -1,0 +1,30 @@
+use paste::paste;
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
+
+macro_rules! impl_code_type_for_miscellany {
+    ($T:ty, $canonical_name:literal) => {
+        paste! {
+            pub struct $T;
+
+            impl CodeType for $T  {
+                fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+                    format!("{}", $canonical_name)
+                }
+
+                fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+                    format!("{}", $canonical_name)
+                }
+
+                fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+                    unreachable!()
+                }
+
+                fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
+                    nm.to_string()
+                }
+            }
+        }
+    };
+}
+
+impl_code_type_for_miscellany!(TimestampCodeType, "Date");

--- a/src/gen_typescript/mod.rs
+++ b/src/gen_typescript/mod.rs
@@ -23,7 +23,7 @@ mod record;
 
 // Keywords to fix
 static KEYWORDS: Lazy<HashSet<String>> = Lazy::new(|| {
-    let list = vec!["Function", "Number", "Object", "String", "Symbol"];
+    let list = vec!["Function", "Number", "Object", "Record", "String", "Symbol"];
     HashSet::from_iter(list.into_iter().map(|s| s.to_string()))
 });
 

--- a/src/gen_typescript/mod.rs
+++ b/src/gen_typescript/mod.rs
@@ -27,6 +27,11 @@ static KEYWORDS: Lazy<HashSet<String>> = Lazy::new(|| {
     HashSet::from_iter(list.into_iter().map(|s| s.to_string()))
 });
 
+static IGNORED_FUNCTIONS: Lazy<HashSet<String>> = Lazy::new(|| {
+    let list = vec!["connect", "set_log_stream"];
+    HashSet::from_iter(list.into_iter().map(|s| s.to_string()))
+});
+
 #[derive(Template)]
 #[template(syntax = "rn", escape = "none", path = "wrapper.ts")]
 pub struct Generator<'a> {
@@ -203,5 +208,9 @@ pub mod filters {
             _ => Ok("".into())
         };
         res
+    }
+
+    pub fn ignored_function(nm: &str) -> Result<bool, askama::Error> {
+        Ok(IGNORED_FUNCTIONS.contains(nm))
     }
 }

--- a/src/gen_typescript/mod.rs
+++ b/src/gen_typescript/mod.rs
@@ -1,0 +1,179 @@
+use std::collections::HashSet;
+
+use askama::Template;
+use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
+use once_cell::sync::Lazy;
+use uniffi_bindgen::backend::{CodeOracle, CodeType, TypeIdentifier};
+use uniffi_bindgen::interface::*;
+
+pub use uniffi_bindgen::bindings::kotlin::gen_kotlin::*;
+
+use crate::generator::RNConfig;
+
+mod callback_interface;
+mod compounds;
+mod custom;
+mod enum_;
+mod error;
+mod external;
+mod miscellany;
+mod object;
+mod primitives;
+mod record;
+
+// Keywords to fix
+static KEYWORDS: Lazy<HashSet<String>> = Lazy::new(|| {
+    let list = vec!["Function", "Number", "Object", "String", "Symbol"];
+    HashSet::from_iter(list.into_iter().map(|s| s.to_string()))
+});
+
+#[derive(Template)]
+#[template(syntax = "rn", escape = "none", path = "wrapper.ts")]
+pub struct Generator<'a> {
+    config: RNConfig,
+    ci: &'a ComponentInterface,
+}
+
+impl<'a> Generator<'a> {
+    pub fn new(config: RNConfig, ci: &'a ComponentInterface) -> Self {
+        Self { config, ci }
+    }
+}
+
+fn fixup_keyword(name: String, append: String) -> String {
+    if KEYWORDS.contains(&name) {
+        format!("{name}{append}")
+    } else {
+        name
+    }
+}
+
+#[derive(Clone)]
+pub struct TypescriptCodeOracle;
+
+impl TypescriptCodeOracle {
+    // Map `Type` instances to a `Box<dyn CodeType>` for that type.
+    //
+    // There is a companion match in `templates/Types.ts` which performs a similar function for the
+    // template code.
+    //
+    //   - When adding additional types here, make sure to also add a match arm to the `Types.ts` template.
+    //   - To keep things managable, let's try to limit ourselves to these 2 mega-matches
+    fn create_code_type(&self, type_: TypeIdentifier) -> Box<dyn CodeType> {
+        match type_ {
+            Type::UInt8 => Box::new(primitives::UInt8CodeType),
+            Type::Int8 => Box::new(primitives::Int8CodeType),
+            Type::UInt16 => Box::new(primitives::UInt16CodeType),
+            Type::Int16 => Box::new(primitives::Int16CodeType),
+            Type::UInt32 => Box::new(primitives::UInt32CodeType),
+            Type::Int32 => Box::new(primitives::Int32CodeType),
+            Type::UInt64 => Box::new(primitives::UInt64CodeType),
+            Type::Int64 => Box::new(primitives::Int64CodeType),
+            Type::Float32 => Box::new(primitives::Float32CodeType),
+            Type::Float64 => Box::new(primitives::Float64CodeType),
+            Type::Boolean => Box::new(primitives::BooleanCodeType),
+            Type::String => Box::new(primitives::StringCodeType),
+
+            Type::Timestamp => Box::new(miscellany::TimestampCodeType),
+            Type::Duration => {
+                unimplemented!("Duration is not implemented")
+            }
+
+            Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
+            Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
+            Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
+            Type::Error(id) => Box::new(error::ErrorCodeType::new(id)),
+            Type::CallbackInterface(id) => {
+                Box::new(callback_interface::CallbackInterfaceCodeType::new(id))
+            }
+            Type::Optional(inner) => Box::new(compounds::OptionalCodeType::new(*inner)),
+            Type::Sequence(inner) => Box::new(compounds::SequenceCodeType::new(*inner)),
+            Type::Map(key, value) => Box::new(compounds::MapCodeType::new(*key, *value)),
+            Type::External { name, .. } => Box::new(external::ExternalCodeType::new(name)),
+            Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
+
+            Type::Unresolved { name } => {
+                unreachable!("Type `{name}` must be resolved before calling create_code_type")
+            }
+        }
+    }
+}
+
+impl CodeOracle for TypescriptCodeOracle {
+    fn find(&self, type_: &TypeIdentifier) -> Box<dyn CodeType> {
+        self.create_code_type(type_.clone())
+    }
+
+    /// Get the idiomatic Typescript rendering of a class name (for enums, records, errors, etc).
+    fn class_name(&self, nm: &str) -> String {
+        fixup_keyword(nm.to_string().to_upper_camel_case(), "Type".to_string())
+    }
+
+    /// Get the idiomatic Typescript rendering of a function name.
+    fn fn_name(&self, nm: &str) -> String {
+        fixup_keyword(nm.to_string().to_lower_camel_case(), "Fn".to_string())
+    }
+
+    /// Get the idiomatic Typescript rendering of a variable name.
+    fn var_name(&self, nm: &str) -> String {
+        fixup_keyword(nm.to_string().to_lower_camel_case(), "Var".to_string())
+    }
+
+    /// Get the idiomatic Typescript rendering of an individual enum variant.
+    fn enum_variant_name(&self, nm: &str) -> String {
+        fixup_keyword(nm.to_string().to_shouty_snake_case(), "Enum".to_string())
+    }
+
+    /// Get the idiomatic Typescript rendering of an exception name
+    fn error_name(&self, nm: &str) -> String {
+        self.class_name(nm)
+    }
+
+    fn ffi_type_label(&self, ffi_type: &FfiType) -> String {
+        match ffi_type {
+            FfiType::Int8
+            | FfiType::UInt8
+            | FfiType::Int16
+            | FfiType::UInt16
+            | FfiType::Int32
+            | FfiType::UInt32
+            | FfiType::Int64
+            | FfiType::UInt64
+            | FfiType::Float32
+            | FfiType::Float64 => "number".to_string(),
+            FfiType::RustArcPtr(name) => format!("{}SafeHandle", name),
+            FfiType::RustBuffer(_) => "RustBuffer".to_string(),
+            FfiType::ForeignBytes => "ForeignBytes".to_string(),
+            FfiType::ForeignCallback => "ForeignCallback".to_string(),
+        }
+    }
+}
+
+pub mod filters {
+    use uniffi_bindgen::backend::CodeType;
+
+    use super::*;
+
+    fn oracle() -> &'static TypescriptCodeOracle {
+        &TypescriptCodeOracle
+    }
+
+    pub fn type_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
+        Ok(codetype.type_label(oracle()))
+    }
+
+    /// Get the idiomatic Typescript rendering of a function name.
+    pub fn fn_name(nm: &str) -> Result<String, askama::Error> {
+        Ok(oracle().fn_name(nm))
+    }
+
+    /// Get the idiomatic Typescript rendering of a variable name.
+    pub fn var_name(nm: &str) -> Result<String, askama::Error> {
+        Ok(oracle().var_name(nm))
+    }
+
+    /// Get the idiomatic Typescript rendering of an individual enum variant.
+    pub fn enum_variant(nm: &str) -> Result<String, askama::Error> {
+        Ok(oracle().enum_variant_name(nm))
+    }
+}

--- a/src/gen_typescript/mod.rs
+++ b/src/gen_typescript/mod.rs
@@ -176,4 +176,32 @@ pub mod filters {
     pub fn enum_variant(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().enum_variant_name(nm))
     }
+
+    pub fn default_value(
+        t: &TypeIdentifier
+    ) -> Result<String, askama::Error> {
+        let res: Result<String, askama::Error> = match t {
+            Type::Optional(inner) => {
+                let unboxed = inner.as_ref();
+                match unboxed {
+                    Type::UInt8 | 
+                    Type::Int8 | 
+                    Type::UInt16  | 
+                    Type::Int16 | 
+                    Type::UInt32 | 
+                    Type::Int32 | 
+                    Type::UInt64 | 
+                    Type::Int64 | 
+                    Type::Float32 | 
+                    Type::Float64 => Ok(" = 0".into()),
+                    Type::String => Ok(" = \"\"".into()),
+                    Type::Record(_) => Ok(" = {}".into()),
+                    Type::Sequence(_) => Ok(" = []".into()),
+                    _ => Ok("".into())
+                }
+            },
+            _ => Ok("".into())
+        };
+        res
+    }
 }

--- a/src/gen_typescript/object.rs
+++ b/src/gen_typescript/object.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
+
+pub struct ObjectCodeType {
+    id: String,
+}
+
+impl ObjectCodeType {
+    pub fn new(id: String) -> Self {
+        Self { id }
+    }
+}
+
+impl CodeType for ObjectCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        oracle.class_name(&self.id)
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.id)
+    }
+
+    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+        unreachable!();
+    }
+}

--- a/src/gen_typescript/primitives.rs
+++ b/src/gen_typescript/primitives.rs
@@ -1,0 +1,75 @@
+use paste::paste;
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
+use uniffi_bindgen::interface::{types::Type, Radix};
+
+fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn typed_number(type_: &Type, num_str: String) -> String {
+        match type_ {
+            // Bytes, Shorts and Ints can all be inferred from the type.
+            Type::Int8 | Type::Int16 | Type::Int32 => num_str,
+            Type::Int64 => format!("{num_str}L"),
+
+            Type::UInt8 | Type::UInt16 | Type::UInt32 => format!("{num_str}u"),
+            Type::UInt64 => format!("{num_str}uL"),
+
+            Type::Float32 => format!("{num_str}f"),
+            Type::Float64 => num_str,
+            _ => panic!("Unexpected literal: {num_str} is not a number"),
+        }
+    }
+
+    match literal {
+        Literal::Boolean(v) => format!("{v}"),
+        Literal::String(s) => format!("\"{s}\""),
+        Literal::Int(i, radix, type_) => typed_number(
+            type_,
+            match radix {
+                Radix::Octal => format!("{i:#x}"),
+                Radix::Decimal => format!("{i}"),
+                Radix::Hexadecimal => format!("{i:#x}"),
+            },
+        ),
+        Literal::UInt(i, radix, type_) => typed_number(
+            type_,
+            match radix {
+                Radix::Octal => format!("{i:#x}"),
+                Radix::Decimal => format!("{i}"),
+                Radix::Hexadecimal => format!("{i:#x}"),
+            },
+        ),
+        Literal::Float(string, type_) => typed_number(type_, string.clone()),
+
+        _ => unreachable!("Literal"),
+    }
+}
+
+macro_rules! impl_code_type_for_primitive {
+    ($T:ty, $class_name:literal) => {
+        paste! {
+            pub struct $T;
+
+            impl CodeType for $T  {
+                fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+                    $class_name.into()
+                }
+
+                fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+                    render_literal(oracle, &literal)
+                }
+            }
+        }
+    };
+}
+
+impl_code_type_for_primitive!(BooleanCodeType, "boolean");
+impl_code_type_for_primitive!(StringCodeType, "string");
+impl_code_type_for_primitive!(Int8CodeType, "number");
+impl_code_type_for_primitive!(Int16CodeType, "number");
+impl_code_type_for_primitive!(Int32CodeType, "number");
+impl_code_type_for_primitive!(Int64CodeType, "number");
+impl_code_type_for_primitive!(UInt8CodeType, "number");
+impl_code_type_for_primitive!(UInt16CodeType, "number");
+impl_code_type_for_primitive!(UInt32CodeType, "number");
+impl_code_type_for_primitive!(UInt64CodeType, "number");
+impl_code_type_for_primitive!(Float32CodeType, "number");
+impl_code_type_for_primitive!(Float64CodeType, "number");

--- a/src/gen_typescript/record.rs
+++ b/src/gen_typescript/record.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
+
+pub struct RecordCodeType {
+    id: String,
+}
+
+impl RecordCodeType {
+    pub fn new(id: String) -> Self {
+        Self { id }
+    }
+}
+
+impl CodeType for RecordCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        oracle.class_name(&self.id)
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.id)
+    }
+
+    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+        unreachable!();
+    }
+}

--- a/src/gen_typescript/templates/Enum.ts
+++ b/src/gen_typescript/templates/Enum.ts
@@ -1,0 +1,26 @@
+{%- let e = ci.get_enum_definition(name).unwrap() %}
+{%- if e.is_flat() %}
+
+export enum {{ type_name }} {
+    {% for variant in e.variants() -%}
+    {{ variant.name()|enum_variant }} = "{{ variant.name()|var_name }}"{% if !loop.last %},
+    {% endif %}
+    {%- endfor %}
+}
+
+{%- else %}
+
+export enum {{ type_name }}Variant {
+    {% for variant in e.variants() -%}
+    {{ variant.name()|enum_variant }} = "{{ variant.name()|var_name }}"{% if !loop.last %},
+    {% endif %}
+    {%- endfor %}
+}
+
+export type {{ type_name }} = {% for variant in e.variants() -%}{
+    type: {{ type_name }}Variant.{{ variant.name()|enum_variant }}{% if variant.has_fields() %}, 
+    {%- call ts::field_list_decl(variant) -%}{% endif %}
+}{% if !loop.last %} | {% endif %}
+{%- endfor %}
+
+{%- endif %}

--- a/src/gen_typescript/templates/Function.ts
+++ b/src/gen_typescript/templates/Function.ts
@@ -1,4 +1,11 @@
-export const {{func.name()|fn_name}} = async ({%- call ts::arg_list_decl(func) -%}): Promise<string> => {
+{%- match func.return_type() -%}
+{%- when Some with (return_type) %}
+export const {{ func.name()|fn_name }} = async ({%- call ts::arg_list_decl(func) -%}): Promise<{{ return_type|type_name }}> => {
     const response = await BreezSDK.{{func.name()|fn_name}}({%- call ts::arg_list(func) -%})
     return response
 }
+{%- when None %}
+export const {{ func.name()|fn_name }} = async ({%- call ts::arg_list_decl(func) -%}): Promise<void> => {
+    await BreezSDK.{{ func.name()|fn_name }}({%- call ts::arg_list(func) -%})
+}
+{%- endmatch %}

--- a/src/gen_typescript/templates/Function.ts
+++ b/src/gen_typescript/templates/Function.ts
@@ -1,0 +1,4 @@
+export const {{func.name()|fn_name}} = async ({%- call ts::arg_list_decl(func) -%}): Promise<string> => {
+    const response = await BreezSDK.{{func.name()|fn_name}}({%- call ts::arg_list(func) -%})
+    return response
+}

--- a/src/gen_typescript/templates/Helpers.ts
+++ b/src/gen_typescript/templates/Helpers.ts
@@ -1,13 +1,17 @@
-export type EventFn = (breezEvent: BreezEvent) => void
+export type EventListener = (breezEvent: BreezEvent) => void
 
-export type LogEntryFn = (logEntry: LogEntry) => void
+export type LogStream = (logEntry: LogEntry) => void
 
-export const addEventListener = (eventFn: EventFn): EmitterSubscription => {
-    return BreezSDKEmitter.addListener("breezSdkEvent", eventFn)
+export const connect = async (config: Config, seed: number[], listener: EventListener): Promise<EmitterSubscription> => {
+    const subscription = BreezSDKEmitter.addListener("breezSdkLog", listener)
+    
+    await BreezSDK.connect(config, seed)
+
+    return subscription
 }
 
-export const addLogListener = async (logEntryFn: LogEntryFn): Promise<EmitterSubscription> => {
-    const subscription = BreezSDKEmitter.addListener("breezSdkLog", logEntryFn)
+export const setLogStream = async (logStream: LogStream): Promise<EmitterSubscription> => {
+    const subscription = BreezSDKEmitter.addListener("breezSdkLog", logStream)
 
     await BreezSDK.startLogStream()
 

--- a/src/gen_typescript/templates/Helpers.ts
+++ b/src/gen_typescript/templates/Helpers.ts
@@ -3,7 +3,7 @@ export type EventListener = (breezEvent: BreezEvent) => void
 export type LogStream = (logEntry: LogEntry) => void
 
 export const connect = async (config: Config, seed: number[], listener: EventListener): Promise<EmitterSubscription> => {
-    const subscription = BreezSDKEmitter.addListener("breezSdkLog", listener)
+    const subscription = BreezSDKEmitter.addListener("breezSdkEvent", listener)
     
     await BreezSDK.connect(config, seed)
 
@@ -13,7 +13,7 @@ export const connect = async (config: Config, seed: number[], listener: EventLis
 export const setLogStream = async (logStream: LogStream): Promise<EmitterSubscription> => {
     const subscription = BreezSDKEmitter.addListener("breezSdkLog", logStream)
 
-    await BreezSDK.startLogStream()
+    await BreezSDK.setLogStream()
 
     return subscription
 }

--- a/src/gen_typescript/templates/Helpers.ts
+++ b/src/gen_typescript/templates/Helpers.ts
@@ -1,0 +1,15 @@
+export type EventFn = (breezEvent: BreezEvent) => void
+
+export type LogEntryFn = (logEntry: LogEntry) => void
+
+export const addEventListener = (eventFn: EventFn): EmitterSubscription => {
+    return BreezSDKEmitter.addListener("breezSdkEvent", eventFn)
+}
+
+export const addLogListener = async (logEntryFn: LogEntryFn): Promise<EmitterSubscription> => {
+    const subscription = BreezSDKEmitter.addListener("breezSdkLog", logEntryFn)
+
+    await BreezSDK.startLogStream()
+
+    return subscription
+}

--- a/src/gen_typescript/templates/Objects.ts
+++ b/src/gen_typescript/templates/Objects.ts
@@ -3,18 +3,8 @@
 {%- match type_ %}
 {%- when Type::Object ( name ) %}
 {% let obj = ci.get_object_definition(name).unwrap() %}
-{%- for meth in obj.methods() -%}
-{%- match meth.return_type() -%}
-{%- when Some with (return_type) %}
-export const {{ meth.name()|fn_name }} = async ({%- call ts::arg_list_decl(meth) -%}): Promise<{{ return_type|type_name }}> => {
-    const response = await BreezSDK.{{meth.name()|fn_name}}({%- call ts::arg_list(meth) -%})
-    return response
-}
-{%- when None %}
-export const {{ meth.name()|fn_name }} = async ({%- call ts::arg_list_decl(meth) -%}): Promise<void> => {
-    await BreezSDK.{{ meth.name()|fn_name }}({%- call ts::arg_list(meth) -%})
-}
-{%- endmatch %}
+{%- for func in obj.methods() -%}
+{%- include "Function.ts" %}
 {% endfor %}
 {%- else -%}
 {%- endmatch -%}    

--- a/src/gen_typescript/templates/Objects.ts
+++ b/src/gen_typescript/templates/Objects.ts
@@ -1,0 +1,22 @@
+{%- for type_ in ci.iter_types() %}
+{%- let type_name = type_|type_name %}
+{%- match type_ %}
+{%- when Type::Object ( name ) %}
+{% let obj = ci.get_object_definition(name).unwrap() %}
+{%- for meth in obj.methods() -%}
+{%- match meth.return_type() -%}
+{%- when Some with (return_type) %}
+export const {{ meth.name()|fn_name }} = async ({%- call ts::arg_list_decl(meth) -%}): Promise<{{ return_type|type_name }}> => {
+    const response = await BreezSDK.{{meth.name()|fn_name}}({%- call ts::arg_list(meth) -%})
+    return response
+}
+{%- when None %}
+export const {{ meth.name()|fn_name }} = async ({%- call ts::arg_list_decl(meth) -%}): Promise<void> => {
+    await BreezSDK.{{ meth.name()|fn_name }}({%- call ts::arg_list(meth) -%})
+}
+{%- endmatch %}
+{% endfor %}
+{%- else -%}
+{%- endmatch -%}    
+{%- endfor %}
+

--- a/src/gen_typescript/templates/Record.ts
+++ b/src/gen_typescript/templates/Record.ts
@@ -1,0 +1,5 @@
+{%- let rec = ci.get_record_definition(name).unwrap() %}
+
+export type {{ type_name }} = {
+    {%- call ts::field_list_decl(rec) %}
+}

--- a/src/gen_typescript/templates/Types.ts
+++ b/src/gen_typescript/templates/Types.ts
@@ -1,0 +1,10 @@
+{%- for type_ in ci.iter_types() %}
+{%- let type_name = type_|type_name %}
+{%- match type_ %}
+{%- when Type::Record ( name ) %}
+{%- include "Record.ts" %}
+{%- when Type::Enum ( name ) %}
+{%- include "Enum.ts" %}
+{%- else %}
+{%- endmatch -%}    
+{%- endfor %}

--- a/src/gen_typescript/templates/macros.ts
+++ b/src/gen_typescript/templates/macros.ts
@@ -26,11 +26,7 @@
 
 {% macro arg_list_decl(func) %}
     {%- for arg in func.arguments() -%}
-        {{ arg.name()|var_name }}: {{ arg|type_name -}}
-        {%- match arg.type_() %}
-        {%- when Type::Optional(inner) %} = 0
-        {%- else %}
-        {%- endmatch %}
+        {{ arg.name()|var_name }}: {{ arg|type_name }}{{- arg.type_()|default_value -}}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
 {%- endmacro %}

--- a/src/gen_typescript/templates/macros.ts
+++ b/src/gen_typescript/templates/macros.ts
@@ -1,0 +1,49 @@
+
+{% macro arg_list(func) %}
+    {%- for arg in func.arguments() -%}
+        {{ arg.name()|var_name -}}
+        {%- if !loop.last %}, {% endif -%}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro field_list(rec) %}
+    {%- for f in rec.fields() %}
+        {{ f.name()|var_name|unquote }},
+    {%- endfor %}
+{%- endmacro -%}
+
+{%- macro field_list_decl(rec) %}
+    {%- for f in rec.fields() %}
+    {%- match f.type_() %}
+    {%- when Type::Optional(inner) %}
+    {%- let unboxed = inner.as_ref() %}
+    {{ f.name()|var_name }}?: {{ unboxed|type_name }}
+    {%- else %}
+    {{ f.name()|var_name }}: {{ f.type_()|type_name }}
+    {%- endmatch %}
+    {%- endfor %}
+{%- endmacro -%}
+
+{% macro arg_list_decl(func) %}
+    {%- for arg in func.arguments() -%}
+        {{ arg.name()|var_name }}: {{ arg|type_name -}}
+        {%- match arg.type_() %}
+        {%- when Type::Optional(inner) %} = 0
+        {%- else %}
+        {%- endmatch %}
+        {%- if !loop.last %}, {% endif -%}
+    {%- endfor %}
+{%- endmacro %}
+
+{% macro return_value(ret_type) %}   
+    {%- match ret_type %}
+    {%- when Type::Enum(_) %}
+    readableMapOf(res)
+    {%- when Type::Record(_) %}
+    readableMapOf(res)
+    {%- when Type::Sequence(_) %}
+    readableArrayOf(res)
+    {%- else %}
+    res
+    {%- endmatch %}
+{%- endmacro %}

--- a/src/gen_typescript/templates/macros.ts
+++ b/src/gen_typescript/templates/macros.ts
@@ -34,16 +34,3 @@
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
 {%- endmacro %}
-
-{% macro return_value(ret_type) %}   
-    {%- match ret_type %}
-    {%- when Type::Enum(_) %}
-    readableMapOf(res)
-    {%- when Type::Record(_) %}
-    readableMapOf(res)
-    {%- when Type::Sequence(_) %}
-    readableArrayOf(res)
-    {%- else %}
-    res
-    {%- endmatch %}
-{%- endmacro %}

--- a/src/gen_typescript/templates/wrapper.ts
+++ b/src/gen_typescript/templates/wrapper.ts
@@ -1,0 +1,27 @@
+import { NativeModules, Platform, EmitterSubscription, NativeEventEmitter } from "react-native"
+
+const LINKING_ERROR =
+    `The package 'react-native-breez-sdk' doesn't seem to be linked. Make sure: \n\n` +
+    Platform.select({ ios: "- You have run 'pod install'\n", default: "" }) +
+    "- You rebuilt the app after installing the package\n" +
+    "- You are not using Expo managed workflow\n"
+
+const BreezSDK = NativeModules.RNBreezSDK
+    ? NativeModules.RNBreezSDK
+    : new Proxy(
+          {},
+          {
+              get() {
+                  throw new Error(LINKING_ERROR)
+              }
+          }
+      )
+
+const BreezSDKEmitter = new NativeEventEmitter(BreezSDK)
+{%- import "macros.ts" as ts %}
+{%- include "Types.ts" %}
+{% include "Helpers.ts" %}
+{% for func in ci.function_definitions() %}
+{% include "Function.ts" %}
+{% endfor %}
+{%- include "Objects.ts" %}

--- a/src/gen_typescript/templates/wrapper.ts
+++ b/src/gen_typescript/templates/wrapper.ts
@@ -22,6 +22,6 @@ const BreezSDKEmitter = new NativeEventEmitter(BreezSDK)
 {%- include "Types.ts" %}
 {% include "Helpers.ts" %}
 {% for func in ci.function_definitions() %}
-{% include "Function.ts" %}
+{%- include "Function.ts" %}
 {% endfor %}
 {%- include "Objects.ts" %}

--- a/src/gen_typescript/templates/wrapper.ts
+++ b/src/gen_typescript/templates/wrapper.ts
@@ -22,6 +22,8 @@ const BreezSDKEmitter = new NativeEventEmitter(BreezSDK)
 {%- include "Types.ts" %}
 {% include "Helpers.ts" %}
 {% for func in ci.function_definitions() %}
+{%- if func.name()|ignored_function == false -%}
 {%- include "Function.ts" %}
-{% endfor %}
+{% endif -%}
+{% endfor -%}
 {%- include "Objects.ts" %}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -8,9 +8,67 @@ use std::io::Write;
 use std::process::Command;
 use uniffi_bindgen::{BindingGenerator, BindingGeneratorConfig, ComponentInterface};
 
-use crate::{gen_kotlin, gen_typescript};
+use crate::gen_kotlin;
+use crate::gen_typescript;
 
 pub struct RNBindingGenerator {}
+
+impl RNBindingGenerator {
+    fn write_kotlin_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: RNConfig,
+        out_dir: &Utf8Path,
+    ) -> Result<()> {
+        // generate kotlin
+        let kotlin_output = self::gen_kotlin::Generator::new(config.clone(), ci)
+            .render()
+            .map_err(anyhow::Error::new)?;
+        let kotlin_out_file = out_dir.join(Utf8Path::new(
+            "android/src/main/java/com/breezsdk/BreezSDKMapper.kt",
+        ));
+        let mut f = File::create(&kotlin_out_file)?;
+        write!(f, "{}", kotlin_output)?;
+        if let Err(e) = Command::new("ktlint")
+            .arg("-F")
+            .arg(&kotlin_out_file)
+            .output()
+        {
+            println!(
+                "Warning: Unable to auto-format {} using ktlint: {:?}",
+                kotlin_out_file.file_name().unwrap(),
+                e
+            )
+        }
+        Ok(())
+    }
+
+    fn write_typescript_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: RNConfig,
+        out_dir: &Utf8Path,
+    ) -> Result<()> {
+        let res = self::gen_typescript::Generator::new(config.clone(), &ci)
+            .render()
+            .map_err(anyhow::Error::new)?;
+        print!("{}", res);
+        let mut out_file = out_dir.join(Utf8Path::new("src"));
+        fs::create_dir_all(out_file.clone())?;
+        out_file.push(Utf8Path::new("index.ts"));
+        let mut f = File::create(&out_file)?;
+        write!(f, "{}", res)?;
+        if let Err(e) = Command::new("tslint").arg("--fix").arg(&out_file).output() {
+            println!(
+                "Warning: Unable to auto-format {} using tslint: {:?}",
+                out_file.file_name().unwrap(),
+                e
+            )
+        }
+        print!("{out_file}");
+        Ok(())
+    }
+}
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct RNConfig {
@@ -42,60 +100,6 @@ impl BindingGeneratorConfig for RNConfig {
     }
 }
 
-impl RNBindingGenerator {
-    fn write_kotlin_bindings(
-        &self,
-        ci: &ComponentInterface,
-        config: &RNConfig,
-        out_dir: &Utf8Path,
-    ) -> Result<()> {
-        let res = self::gen_kotlin::Generator::new(config.clone(), &ci)
-            .render()
-            .map_err(anyhow::Error::new)?;
-        print!("{}", res);
-        let mut out_file = out_dir.join(Utf8Path::new("android/src/main/java/com/breezsdk"));
-        fs::create_dir_all(out_file.clone())?;
-        out_file.push(Utf8Path::new("BreezSDKMapper.kt"));
-        let mut f = File::create(&out_file)?;
-        write!(f, "{}", res)?;
-        if let Err(e) = Command::new("ktlint").arg("-F").arg(&out_file).output() {
-            println!(
-                "Warning: Unable to auto-format {} using ktlint: {:?}",
-                out_file.file_name().unwrap(),
-                e
-            )
-        }
-        print!("{out_file}");
-        Ok(())
-    }
-
-    fn write_typescript_bindings(
-        &self,
-        ci: &ComponentInterface,
-        config: &RNConfig,
-        out_dir: &Utf8Path,
-    ) -> Result<()> {
-        let res = self::gen_typescript::Generator::new(config.clone(), &ci)
-            .render()
-            .map_err(anyhow::Error::new)?;
-        print!("{}", res);
-        let mut out_file = out_dir.join(Utf8Path::new("src"));
-        fs::create_dir_all(out_file.clone())?;
-        out_file.push(Utf8Path::new("index.ts"));
-        let mut f = File::create(&out_file)?;
-        write!(f, "{}", res)?;
-        if let Err(e) = Command::new("tslint").arg("--fix").arg(&out_file).output() {
-            println!(
-                "Warning: Unable to auto-format {} using tslint: {:?}",
-                out_file.file_name().unwrap(),
-                e
-            )
-        }
-        print!("{out_file}");
-        Ok(())
-    }
-}
-
 impl BindingGenerator for RNBindingGenerator {
     type Config = RNConfig;
 
@@ -105,8 +109,13 @@ impl BindingGenerator for RNBindingGenerator {
         config: Self::Config,
         out_dir: &Utf8Path,
     ) -> Result<()> {
-        self.write_kotlin_bindings(&ci, &config, out_dir)?;
-        self.write_typescript_bindings(&ci, &config, out_dir)?;
+        fs::create_dir_all(out_dir)?;
+
+        // generate kotlin
+        self.write_kotlin_bindings(&ci, config.clone(), out_dir)?;
+
+        // generate typescript
+        self.write_typescript_bindings(&ci, config.clone(), out_dir)?;
         Ok(())
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -52,7 +52,6 @@ impl RNBindingGenerator {
         let res = self::gen_typescript::Generator::new(config.clone(), &ci)
             .render()
             .map_err(anyhow::Error::new)?;
-        print!("{}", res);
         let mut out_file = out_dir.join(Utf8Path::new("src"));
         fs::create_dir_all(out_file.clone())?;
         out_file.push(Utf8Path::new("index.ts"));
@@ -65,7 +64,6 @@ impl RNBindingGenerator {
                 e
             )
         }
-        print!("{out_file}");
         Ok(())
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use std::process::Command;
 use uniffi_bindgen::{BindingGenerator, BindingGeneratorConfig, ComponentInterface};
 
-use crate::gen_kotlin;
+use crate::{gen_kotlin, gen_typescript};
 
 pub struct RNBindingGenerator {}
 
@@ -42,23 +42,20 @@ impl BindingGeneratorConfig for RNConfig {
     }
 }
 
-impl BindingGenerator for RNBindingGenerator {
-    type Config = RNConfig;
-
-    fn write_bindings(
+impl RNBindingGenerator {
+    fn write_kotlin_bindings(
         &self,
-        ci: ComponentInterface,
-        config: Self::Config,
+        ci: &ComponentInterface,
+        config: &RNConfig,
         out_dir: &Utf8Path,
     ) -> Result<()> {
         let res = self::gen_kotlin::Generator::new(config.clone(), &ci)
             .render()
             .map_err(anyhow::Error::new)?;
         print!("{}", res);
-        fs::create_dir_all(out_dir)?;
-        let out_file = out_dir.join(Utf8Path::new(
-            "android/src/main/java/com/breezsdk/BreezSDKMapper.kt",
-        ));
+        let mut out_file = out_dir.join(Utf8Path::new("android/src/main/java/com/breezsdk"));
+        fs::create_dir_all(out_file.clone())?;
+        out_file.push(Utf8Path::new("BreezSDKMapper.kt"));
         let mut f = File::create(&out_file)?;
         write!(f, "{}", res)?;
         if let Err(e) = Command::new("ktlint").arg("-F").arg(&out_file).output() {
@@ -69,6 +66,47 @@ impl BindingGenerator for RNBindingGenerator {
             )
         }
         print!("{out_file}");
+        Ok(())
+    }
+
+    fn write_typescript_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &RNConfig,
+        out_dir: &Utf8Path,
+    ) -> Result<()> {
+        let res = self::gen_typescript::Generator::new(config.clone(), &ci)
+            .render()
+            .map_err(anyhow::Error::new)?;
+        print!("{}", res);
+        let mut out_file = out_dir.join(Utf8Path::new("src"));
+        fs::create_dir_all(out_file.clone())?;
+        out_file.push(Utf8Path::new("index.ts"));
+        let mut f = File::create(&out_file)?;
+        write!(f, "{}", res)?;
+        if let Err(e) = Command::new("tslint").arg("--fix").arg(&out_file).output() {
+            println!(
+                "Warning: Unable to auto-format {} using tslint: {:?}",
+                out_file.file_name().unwrap(),
+                e
+            )
+        }
+        print!("{out_file}");
+        Ok(())
+    }
+}
+
+impl BindingGenerator for RNBindingGenerator {
+    type Config = RNConfig;
+
+    fn write_bindings(
+        &self,
+        ci: ComponentInterface,
+        config: Self::Config,
+        out_dir: &Utf8Path,
+    ) -> Result<()> {
+        self.write_kotlin_bindings(&ci, &config, out_dir)?;
+        self.write_typescript_bindings(&ci, &config, out_dir)?;
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod gen_kotlin;
+mod gen_typescript;
 mod generator;
 use camino::Utf8Path;
 use clap::Parser;

--- a/tslint.json
+++ b/tslint.json
@@ -65,13 +65,10 @@
       "prefer-const": true,
       "quotemark": [
         true,
-        "single"
+        "double"
       ],
       "radix": true,
-      "semicolon": [
-        true,
-        "always"
-      ],
+      "semicolon": false,
       "triple-equals": [
         true,
         "allow-null-check"

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,100 @@
+{
+    "extends": "tslint:recommended",
+    "rules": {
+      "callable-types": true,
+      "class-name": true,
+      "comment-format": [
+        true,
+        "check-space"
+      ],
+      "curly": true,
+      "eofline": true,
+      "forin": true,
+      "import-blacklist": [
+        true
+      ],
+      "import-spacing": true,
+      "indent": [
+        true,
+        "spaces"
+      ],
+      "interface-over-type-literal": true,
+      "label-position": true,
+      "member-access": false,
+      "member-ordering": [
+        true,
+        {
+          "order": "fields-first"
+        }
+      ],
+      "no-arg": true,
+      "no-bitwise": true,
+      "no-console": [
+        true,
+        "debug",
+        "info",
+        "time",
+        "timeEnd",
+        "trace"
+      ],
+      "no-construct": true,
+      "no-debugger": true,
+      "no-duplicate-variable": true,
+      "no-empty": false,
+      "no-empty-interface": true,
+      "no-eval": true,
+      "no-inferrable-types": [
+        true,
+        "ignore-params"
+      ],
+      "no-shadowed-variable": false,
+      "no-string-literal": false,
+      "no-string-throw": true,
+      "no-switch-case-fall-through": true,
+      "no-trailing-whitespace": true,
+      "no-unused-expression": true,
+      "no-var-keyword": true,
+      "object-literal-sort-keys": false,
+      "one-line": [
+        true,
+        "check-open-brace",
+        "check-catch",
+        "check-else",
+        "check-whitespace"
+      ],
+      "prefer-const": true,
+      "quotemark": [
+        true,
+        "single"
+      ],
+      "radix": true,
+      "semicolon": [
+        true,
+        "always"
+      ],
+      "triple-equals": [
+        true,
+        "allow-null-check"
+      ],
+      "typedef-whitespace": [
+        true,
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        }
+      ],
+      "unified-signatures": true,
+      "variable-name": false,
+      "whitespace": [
+        true,
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type"
+      ]
+    }
+  }


### PR DESCRIPTION
This PR generates the typescript file which interfaces over the RN bridge to the native generated interface.

- [x] Add TypescriptCodeOracle
- [x] Add templates
- [x] Adapt generated `connect` and `setLogStream` functions for the RN bridge
- [x] Set default values for optional function arguments