### PR TITLE
Separate type conversion with appending to list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-rn-generator"
-version = "0.1.4"
+version = "0.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gen_swift/templates/RecordTemplate.swift
+++ b/src/gen_swift/templates/RecordTemplate.swift
@@ -36,7 +36,8 @@ static func  as{{ type_name }}List(arr: [Any]) throws -> [{{ type_name }}] {
     var list = [{{ type_name }}]()
     for value in arr {
         if let val = value as? [String: Any?] {
-            list.append(try as{{ type_name }}(data: val))
+            var {{ type_name|var_name|unquote }} = try as{{ type_name }}(data: val)
+            list.append({{ type_name|var_name|unquote }})
         } else { 
             throw SdkError.Generic(message: "Invalid element type {{ type_name }}")
         }


### PR DESCRIPTION
Separates the type conversion with appending to the list to avoid try hoisting

Before:
```
static func  asPaymentList(arr: [Any]) throws -> [Payment] {
    var list = [Payment]()
    for value in arr { 
        if let val = value as? [String: Any?] {
            list.append(try asPayment(data: val))
        } else {
            throw SdkError.Generic(message: "Invalid element type Payment")
        }
    }
    return list
}
```
After:
```
static func  asPaymentList(arr: [Any]) throws -> [Payment] {
    var list = [Payment]()
    for value in arr { 
        if let val = value as? [String: Any?] {
            var payment = try asPayment(data: val)
            list.append(payment)
        } else {
            throw SdkError.Generic(message: "Invalid element type Payment")
        }
    }
    return list
}
```