### PR TITLE
add node logger code generation

### DIFF
--- a/src/gen_kotlin/templates/module.kt
+++ b/src/gen_kotlin/templates/module.kt
@@ -62,7 +62,12 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun connect(config: ReadableMap, seed: ReadableArray, promise: Promise) {
+    fun connect(
+        config: ReadableMap,
+        seed: ReadableArray,
+        logFilePath: String,
+        promise: Promise,
+    ) {
         if (breezServices != null) {
             promise.reject(TAG, "BreezServices already initialized")
             return
@@ -71,8 +76,9 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         try {
             val configTmp = asConfig(config) ?: run { throw SdkException.Generic("Missing mandatory field config of type Config") }
             val emitter = reactApplicationContext.getJSModule(RCTDeviceEventEmitter::class.java)
-
-            breezServices = connect(configTmp, asUByteList(seed), BreezSDKListener(emitter))
+            val logFilePathTmp = logFilePath.takeUnless { it.isEmpty() }
+            
+            breezServices = connect(configTmp, asUByteList(seed), BreezSDKListener(emitter), BreezSDKNodeLogger(emitter), logFilePathTmp)
             promise.resolve(readableMapOf("status" to "ok"))
         } catch (e: SdkException) {
             e.printStackTrace()

--- a/src/gen_swift/templates/extern.m
+++ b/src/gen_swift/templates/extern.m
@@ -15,6 +15,7 @@ RCT_EXTERN_METHOD(
 RCT_EXTERN_METHOD(
     connect: (NSDictionary*)config
     seed: (NSArray*)seed
+    logFilePath: (NSString*)logFilePath
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/src/gen_swift/templates/module.swift
+++ b/src/gen_swift/templates/module.swift
@@ -24,7 +24,7 @@ class RNBreezSDK: RCTEventEmitter {
     }
     
     override func supportedEvents() -> [String]! {
-        return [BreezSDKListener.emitterName, BreezSDKLogStream.emitterName]
+        return [BreezSDKListener.emitterName, BreezSDKLogStream.emitterName, BreezSDKNodeLogger.emitterName]
     }
     
     @objc
@@ -56,8 +56,8 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
     
-    @objc(connect:seed:resolve:reject:)
-    func connect(_ config:[String: Any], seed:[UInt8], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+    @objc(connect:seed:logFilePath:resolve:reject:)
+    func connect(_ config: [String: Any], seed: [UInt8], logFilePath: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         if self.breezServices != nil {
             reject(RNBreezSDK.TAG, "BreezServices already initialized", nil)
             return
@@ -65,7 +65,8 @@ class RNBreezSDK: RCTEventEmitter {
             
         do {
             let configTmp = try BreezSDKMapper.asConfig(data: config)
-            self.breezServices = try BreezSDK.connect(config: configTmp, seed: seed, listener: BreezSDKListener(emitter: self))                
+            let logFilePathTmp = logFilePath.isEmpty ? nil : logFilePath
+            breezServices = try BreezSDK.connect(config: configTmp, seed: seed, listener: BreezSDKListener(emitter: self), nodeLogger: BreezSDKNodeLogger(emitter: self), logFilePath: logFilePathTmp)             
             resolve(["status": "ok"])
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/src/gen_typescript/templates/Helpers.ts
+++ b/src/gen_typescript/templates/Helpers.ts
@@ -2,10 +2,14 @@ export type EventListener = (breezEvent: BreezEvent) => void
 
 export type LogStream = (logEntry: LogEntry) => void
 
-export const connect = async (config: Config, seed: number[], listener: EventListener): Promise<EmitterSubscription> => {
+export type Logger = (logMessage: LogMessage) => void
+
+export const connect = async (config: Config, seed: number[], listener: EventListener, nodeLogger: Logger, logFilePath?: string ): Promise<EmitterSubscription> => {
     const subscription = BreezSDKEmitter.addListener("breezSdkEvent", listener)
     
-    await BreezSDK.connect(config, seed)
+    BreezSDKEmitter.addListener("breezSdkNodeLog", nodeLogger)
+
+    await BreezSDK.connect(config, seed, logFilePath)
 
     return subscription
 }


### PR DESCRIPTION
In https://github.com/breez/breez-sdk/pull/467, we give the opportunity to provide a logger and an optional log file path, when connecting to a node.

this PR reflects these changes when generating RN bindings