### PR TITLE
Fix generation of variants with multiple variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-rn-generator"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gen_kotlin/templates/EnumTemplate.kt
+++ b/src/gen_kotlin/templates/EnumTemplate.kt
@@ -31,7 +31,7 @@ fun readableMapOf({{ type_name|var_name|unquote }}: {{ type_name }}): ReadableMa
         pushToMap(map, "type", "{{ variant.name()|var_name|unquote }}")
         {% for f in variant.fields() -%}
         pushToMap(map, "{{ f.name()|var_name|unquote }}", {{ f.type_()|render_to_map(ci,type_name|var_name|unquote,f.name()|var_name|unquote, false) }})                    
-        {%- endfor %}
+        {% endfor -%}
     }
     {% endfor %}
     }

--- a/src/gen_swift/templates/EnumTemplate.swift
+++ b/src/gen_swift/templates/EnumTemplate.swift
@@ -68,7 +68,7 @@ static func dictionaryOf({{ type_name|var_name|unquote }}: {{ type_name }}) -> [
     {%- for variant in e.variants() %}
     {% if variant.has_fields() %}
     case let .{{ variant.name()|var_name|unquote }}(
-        {% for f in variant.fields() %}{{f.name()|var_name|unquote}}{%- endfor %}
+        {% for f in variant.fields() %}{{f.name()|var_name|unquote}}{%- if !loop.last %}, {% endif -%}{%- endfor %}
     ):
     {% else %}
     case .{{ variant.name()|var_name|unquote }}:  


### PR DESCRIPTION
Fixes an issue generating code when there are multiple variables in an interface variant.

Identified in breez/breez-sdk#550