### PR TITLE
Improve workingDir and disconnect handling 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-rn-generator"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gen_kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/src/gen_kotlin/templates/TopLevelFunctionTemplate.kt
@@ -22,12 +22,8 @@
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
                 val res = {{ obj_interface }}{{ func.name()|fn_name|unquote }}({%- call kt::arg_list(func) -%})
- {%- if func.name() == "default_config" %}
+{%- if func.name() == "default_config" %}
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
-
-                if (!workingDir.exists()) {
-                    workingDir.mkdirs()
-                }
 
                 res.workingDir = workingDir.absolutePath
 {%- endif -%}               
@@ -40,6 +36,9 @@
     {%- endmatch %}
 {%- when None %}
                 {{ obj_interface }}{{ func.name()|fn_name|unquote }}({%- call kt::arg_list(func) -%})
+{%- if func.name() == "disconnect" %}
+                breezServices = null
+{%- endif %}               
                 promise.resolve(readableMapOf("status" to "ok"))
 {%- endmatch %}
             } catch (e: Exception) {

--- a/src/gen_kotlin/templates/module.kt
+++ b/src/gen_kotlin/templates/module.kt
@@ -36,6 +36,19 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         throw SdkException.Generic("BreezServices not initialized")
     }
 
+    @Throws(SdkException::class)
+    private fun ensureWorkingDir(workingDir: String) {
+        try {
+            val workingDirFile = File(workingDir)
+
+            if (!workingDirFile.exists() && !workingDirFile.mkdirs()) {
+                throw SdkException.Generic("Mandatory field workingDir must contain a writable directory")
+            }
+        } catch (e: SecurityException) {
+            throw SdkException.Generic("Mandatory field workingDir must contain a writable directory")
+        }
+    }
+
     @ReactMethod
     fun addListener(eventName: String) {}
 
@@ -71,6 +84,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         try {
             val configTmp = asConfig(config) ?: run { throw SdkException.Generic("Missing mandatory field config of type Config") }
             val emitter = reactApplicationContext.getJSModule(RCTDeviceEventEmitter::class.java)
+
+            ensureWorkingDir(configTmp.workingDir)
 
             breezServices = connect(configTmp, asUByteList(seed), BreezSDKListener(emitter))
             promise.resolve(readableMapOf("status" to "ok"))

--- a/src/gen_swift/templates/TopLevelFunctionTemplate.swift
+++ b/src/gen_swift/templates/TopLevelFunctionTemplate.swift
@@ -22,7 +22,7 @@
 {%- when Some with (return_type) %}
             var res = {%- call swift::throws_decl(func) -%}{{ obj_interface }}{{ func.name()|fn_name|unquote }}({%- call swift::arg_list(func) -%})
 {%- if func.name() == "default_config" %}
-            res.workingDir = RNBreezSDK.breezSdkDirectory.path                
+            res.workingDir = RNBreezSDK.breezSdkDirectory.path
 {%- endif -%}
     {%- match return_type %}
     {%- when Type::Optional(inner) %}
@@ -37,6 +37,9 @@
     {%- endmatch %}
 {%- when None %}
             try {{ obj_interface }}{{ func.name()|fn_name|unquote }}({%- call swift::arg_list(func) -%})
+{%- if func.name() == "disconnect" %}
+            breezServices = nil
+{%- endif %}
             resolve(["status": "ok"])     
 {%- endmatch %}
         } catch let err {

--- a/src/gen_swift/templates/module.swift
+++ b/src/gen_swift/templates/module.swift
@@ -6,19 +6,16 @@ class RNBreezSDK: RCTEventEmitter {
     static let TAG: String = "BreezSDK"
     
     private var breezServices: BlockingBreezServices!
-    
-    static var applicationDirectory: URL {
-      return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    }
 
     static var breezSdkDirectory: URL {
-      let breezSdkDirectory = applicationDirectory.appendingPathComponent("breezSdk", isDirectory: true)
-      
-      if !FileManager.default.fileExists(atPath: breezSdkDirectory.path) {
-        try! FileManager.default.createDirectory(atPath: breezSdkDirectory.path, withIntermediateDirectories: true)
-      }
-      
-      return breezSdkDirectory
+        let applicationDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let breezSdkDirectory = applicationDirectory.appendingPathComponent("breezSdk", isDirectory: true)
+        
+        if !FileManager.default.fileExists(atPath: breezSdkDirectory.path) {
+            try! FileManager.default.createDirectory(atPath: breezSdkDirectory.path, withIntermediateDirectories: true)
+        }
+        
+        return breezSdkDirectory
     }
     
     @objc


### PR DESCRIPTION
This PR enables different nodes to be run through RN (one at a time) by allowing the workingDir to be set as a subdirectory of the application directory and resetting the breezServices instance when disconnect is called.

Generated code breez/breez-sdk#571