### PR TITLE
change from class too enum for BreezSDKMapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-rn-generator"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gen_swift/templates/mapper.swift
+++ b/src/gen_swift/templates/mapper.swift
@@ -2,7 +2,7 @@
 import Foundation
 import BreezSDK
 
-class BreezSDKMapper {
+enum BreezSDKMapper {
 
 {%- include "Types.swift" %}
 


### PR DESCRIPTION
The latest version of  SwiftFormat https://github.com/nicklockwood/SwiftFormat/releases/tag/0.52.9 includes the following bugfix.  

> - Fixed bug where enumNamespaces rule wouldn't be applied immediately after an import statement

Applied the change to the rn-generator in order to get the same result.





