### PR TITLE
iOS emitter fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-rn-generator"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gen_kotlin/mod.rs
+++ b/src/gen_kotlin/mod.rs
@@ -80,10 +80,6 @@ pub mod filters {
         Ok(codetype.type_label(oracle()))
     }
 
-    pub fn error_name(nm: &str) -> Result<String, askama::Error> {
-        Ok(oracle().error_name(nm))
-    }
-
     pub fn fn_name(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().fn_name(nm))
     }

--- a/src/gen_swift/templates/module.swift
+++ b/src/gen_swift/templates/module.swift
@@ -5,6 +5,8 @@ import BreezSDK
 class RNBreezSDK: RCTEventEmitter {
     static let TAG: String = "BreezSDK"
     
+    public static var emitter: RCTEventEmitter!
+    
     private var breezServices: BlockingBreezServices!
 
     static var breezSdkDirectory: URL {
@@ -18,6 +20,11 @@ class RNBreezSDK: RCTEventEmitter {
         return breezSdkDirectory
     }
     
+    override init() {
+        super.init()
+        RNBreezSDK.emitter = self
+    }
+
     @objc
     override static func moduleName() -> String! {
         TAG
@@ -59,7 +66,7 @@ class RNBreezSDK: RCTEventEmitter {
     @objc(setLogStream:reject:)
     func setLogStream(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            try BreezSDK.setLogStream(logStream: BreezSDKLogStream(emitter: self))            
+            try BreezSDK.setLogStream(logStream: BreezSDKLogStream())            
             resolve(["status": "ok"])        
         } catch let err {
             rejectErr(err: err, reject: reject)
@@ -78,7 +85,7 @@ class RNBreezSDK: RCTEventEmitter {
 
             try ensureWorkingDir(workingDir: configTmp.workingDir)
 
-            self.breezServices = try BreezSDK.connect(config: configTmp, seed: seed, listener: BreezSDKListener(emitter: self))                
+            self.breezServices = try BreezSDK.connect(config: configTmp, seed: seed, listener: BreezSDKListener())                
             resolve(["status": "ok"])
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/src/gen_typescript/mod.rs
+++ b/src/gen_typescript/mod.rs
@@ -6,8 +6,6 @@ use once_cell::sync::Lazy;
 use uniffi_bindgen::backend::{CodeOracle, CodeType, TypeIdentifier};
 use uniffi_bindgen::interface::*;
 
-pub use uniffi_bindgen::bindings::kotlin::gen_kotlin::*;
-
 use crate::generator::RNConfig;
 
 mod callback_interface;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -22,7 +22,7 @@ impl RNBindingGenerator {
         output_path: &Utf8Path,
         file_name: &Utf8Path,
     ) -> Result<Utf8PathBuf> {
-        fs::create_dir_all(output_path.clone())?;
+        fs::create_dir_all(output_path)?;
         let bindings_path: camino::Utf8PathBuf = output_path.join(file_name);
         let mut f: File = File::create(&bindings_path)?;
         write!(f, "{}", bindings_output)?;


### PR DESCRIPTION
On init of the iOS native module, set the static class emitter variable. The static emitter can then be used by the event listener and log stream to emit events over the react native bridge.

Generated code https://github.com/breez/breez-sdk/pull/722