### PR TITLE
Suppress iOS no listener warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-rn-generator"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gen_swift/templates/module.swift
+++ b/src/gen_swift/templates/module.swift
@@ -6,7 +6,8 @@ class RNBreezSDK: RCTEventEmitter {
     static let TAG: String = "BreezSDK"
     
     public static var emitter: RCTEventEmitter!
-    
+    public static var hasListeners: Bool = false
+
     private var breezServices: BlockingBreezServices!
 
     static var breezSdkDirectory: URL {
@@ -32,6 +33,14 @@ class RNBreezSDK: RCTEventEmitter {
     
     override func supportedEvents() -> [String]! {
         return [BreezSDKListener.emitterName, BreezSDKLogStream.emitterName]
+    }
+    
+    override func startObserving() {
+        RNBreezSDK.hasListeners = true
+    }
+    
+    override func stopObserving() {
+        RNBreezSDK.hasListeners = false
     }
     
     @objc

--- a/src/gen_typescript/templates/Helpers.ts
+++ b/src/gen_typescript/templates/Helpers.ts
@@ -13,7 +13,9 @@ export const connect = async (req: ConnectRequest, listener: EventListener): Pro
 export const setLogStream = async (logStream: LogStream): Promise<EmitterSubscription> => {
     const subscription = BreezSDKEmitter.addListener("breezSdkLog", logStream)
 
-    await BreezSDK.setLogStream()
+    try {
+        await BreezSDK.setLogStream()
+    } catch {}
 
     return subscription
 }


### PR DESCRIPTION
Suppresses iOS warnings when there are no listeners to emitted events

```
WARN  Sending `breezSdkLog` with no listeners registered.
```

Also suppress the setLogStream error if the native log stream handler is already set.

SDK PR https://github.com/breez/breez-sdk/pull/829