### PR TITLE
Add optional filter level param to set log stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-rn-generator"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gen_kotlin/templates/module.kt
+++ b/src/gen_kotlin/templates/module.kt
@@ -62,12 +62,13 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     {% endif -%}
     {%- endfor %}  
     @ReactMethod
-    fun setLogStream(promise: Promise) {
+    fun setLogStream(filterLevel: String?, promise: Promise) {
         executor.execute {
             try {
                 val emitter = reactApplicationContext.getJSModule(RCTDeviceEventEmitter::class.java)
+                val levelFilter = filterLevel?.let { asLevelFilter(filterLevel) }
 
-                setLogStream(BreezSDKLogStream(emitter))
+                setLogStream(BreezSDKLogStream(emitter), levelFilter)
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/src/gen_swift/templates/extern.m
+++ b/src/gen_swift/templates/extern.m
@@ -8,7 +8,8 @@
 {% endif %}
 {%- endfor %}  
 RCT_EXTERN_METHOD(
-    setLogStream: (RCTPromiseResolveBlock)resolve
+    setLogStream: (NSString*)filterLevel
+    resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )
 

--- a/src/gen_swift/templates/module.swift
+++ b/src/gen_swift/templates/module.swift
@@ -72,10 +72,14 @@ class RNBreezSDK: RCTEventEmitter {
     {% include "TopLevelFunctionTemplate.swift" %}
     {% endif -%}
     {%- endfor %}  
-    @objc(setLogStream:reject:)
-    func setLogStream(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+    @objc(setLogStream:resolve:reject:)
+    func setLogStream(_ filterLevel: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            try BreezSDK.setLogStream(logStream: BreezSDKLogStream())            
+            var levelFilter: LevelFilter? = nil
+            if filterLevel != nil {
+                levelFilter = try BreezSDKMapper.asLevelFilter(levelFilter: filterLevel!)
+            }
+            try BreezSDK.setLogStream(logStream: BreezSDKLogStream(), filterLevel: levelFilter)            
             resolve(["status": "ok"])        
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/src/gen_typescript/templates/Helpers.ts
+++ b/src/gen_typescript/templates/Helpers.ts
@@ -10,11 +10,11 @@ export const connect = async (req: ConnectRequest, listener: EventListener): Pro
     return subscription
 }
 
-export const setLogStream = async (logStream: LogStream): Promise<EmitterSubscription> => {
+export const setLogStream = async (logStream: LogStream, filterLevel?: LevelFilter): Promise<EmitterSubscription> => {
     const subscription = BreezSDKEmitter.addListener("breezSdkLog", logStream)
 
     try {
-        await BreezSDK.setLogStream()
+        await BreezSDK.setLogStream(filterLevel)
     } catch {}
 
     return subscription


### PR DESCRIPTION
`setLogStream` and `connect` aren't generated in the same way as the other methods and needs to be updated manually.

Changes required for: 
- https://github.com/breez/breez-sdk/pull/874